### PR TITLE
ARCSPC-427 - resolved download csv not appearing until refresh issue

### DIFF
--- a/frontend/assets/ead_xform.js
+++ b/frontend/assets/ead_xform.js
@@ -1,28 +1,10 @@
-/* any js needed for EAD transforms */
-$(function () {
-    var csvBtnAdded = (typeof  ead_xform_id === 'undefined'); /* if we don't have the id to beginwith, forget it*/    
-/* the defer methodolgy is adapted from https://stackoverflow.com/questions/7486309/how-to-make-script-execution-wait-until-jquery-is-loaded */
-/* since the lower half of the screen loads *after* the javascript is loaded, we need to to this */
-    function defer(method) {
-	if ($("#download-ead-dropdown").length > 0) {
-	    method();
-	}
-	else {
-	    setTimeout(function() { defer(method) }, 50);
-	}
-    }
+// This is embedded directly in resources/toolbar.html.erb because ArchivesSpace core,
+// after visiting a resource page via link (but not on refresh), loads that component
+// twice, overwriting out any additions to the menu
 
-var addCsvBtn = function () {
-	if (!csvBtnAdded) {
-	    var $eadBtn = $("#download-ead-dropdown");
-	    if ($eadBtn.length > 0) {
-		a = '/resources/' +  ead_xform_id + '/staff_csv';
-		$eadBtn.after('<li class="hvd-download-csv"><a href="' + a + '">Download CSV</a></li>');
-		csvBtnAdded = true;
-	    }
-	}
-    };
+let $eadBtn = $("#download-ead-dropdown")
 
-    defer(addCsvBtn);
-
-});
+if ($eadBtn) {
+	a = '/resources/' +  ead_xform_id + '/staff_csv';
+	$eadBtn.after('<li class="hvd-download-csv" id="hvd-download-csv"><a href="' + a + '">Download CSV</a></li>');
+}

--- a/frontend/assets/ead_xform.js
+++ b/frontend/assets/ead_xform.js
@@ -4,7 +4,9 @@
 
 let $eadBtn = $("#download-ead-dropdown")
 
-if ($eadBtn) {
-	a = '/resources/' +  ead_xform_id + '/staff_csv';
-	$eadBtn.after('<li class="hvd-download-csv" id="hvd-download-csv"><a href="' + a + '">Download CSV</a></li>');
+if ($("#hvd-download-csv").length === 0) {
+	if ($eadBtn) {
+		a = '/resources/' +  ead_xform_id + '/staff_csv';
+		$eadBtn.after('<li class="hvd-download-csv" id="hvd-download-csv"><a href="' + a + '">Download CSV</a></li>');
+	}
 }

--- a/frontend/views/layout_head.html.erb
+++ b/frontend/views/layout_head.html.erb
@@ -1,4 +1,0 @@
-<% if controller.controller_name == 'resources' && (controller.action_name == 'edit' || controller.action_name == 'show') %>
-    <script>var ead_xform_id = <%= params[:id] %>;</script>
-    <%= javascript_include_tag "#{@base_url}/assets/ead_xform.js" %> 
- <% end %>

--- a/frontend/views/resources/_toolbar.html.erb
+++ b/frontend/views/resources/_toolbar.html.erb
@@ -1,0 +1,84 @@
+# If this file is changed in core, it must be updated here with our additions included.
+# Our additions are the two script lines at the end.
+
+<% if user_can?('update_resource_record') %>
+
+  <% unless content_for?(:exports) %>
+    <% content_for :exports do %>
+      <li class="dropdown-submenu" id="download-ead-dropdown" data-download-ead-url="<%= url_for(:controller => :exports,
+        :action => :download_ead, :id => @resource.id, :include_unpublished => "${include_unpublished}",
+        :include_daos => "${include_daos}", :numbered_cs => "${numbered_cs}", :print_pdf => "${print_pdf}",
+        :ead3 => "${ead3}" )%>">
+        <a href="#" data-toggle="dropdown" class="menu-with-options download-ead-action" title="<%= I18n.t("actions.export_ead") %>"><%= I18n.t("actions.export_ead") %></a>
+        <div class="dropdown-menu" id="form_download_ead">
+          <fieldset>
+            <input type="hidden" name="id", value="<%= @resource.id %>" />
+            <label class="checkbox" for="include-unpublished">
+              <input type="checkbox" id="include-unpublished" name="include_unpublished" checked="checked"/>
+              <%= I18n.t("export_options.include_unpublished") %>&#160;
+            </label>
+            <label class="checkbox" for="include-daos">
+              <input type="checkbox" id="include-daos" name="include_daos" checked="checked"/>
+              <%= I18n.t("export_options.include_daos") %>&#160;
+            </label>
+            <label class="checkbox" for="numbered-cs">
+              <input type="checkbox" id="numbered-cs" name="numbered_cs" />
+              <%= I18n.t("export_options.numbered_cs") %>&#160;
+            </label>
+            <%# EAD3 %>
+            <label class="checkbox" for="ead3">
+              <input type="checkbox" id="ead3" name="ead3" />
+              <%= I18n.t("export_options.ead3") %>&#160;
+            </label>
+            <%# END - EAD3 %>
+          </fieldset>
+        </div>
+      </li>
+
+      <li class="dropdown-submenu" id="download-marc-dropdown" data-download-marc-url="<%= url_for(:controller => :exports, :action => :download_marc, :id => @resource.id, :include_unpublished_marc => "${include_unpublished_marc}")%>">
+        <a href="#" data-toggle="dropdown" class="menu-with-options download-marc-action" title="<%= I18n.t("actions.export_marc") %>"><%= I18n.t("actions.export_marc") %></a>
+        <div class="dropdown-menu" id="form_download_marc">
+          <fieldset>
+            <input type="hidden" name="id", value="<%= @resource.id %>" />
+            <label class="checkbox" for="include-unpublished-marc">
+              <input type="checkbox" id="include-unpublished-marc" name="include_unpublished_marc" checked="checked"/>
+              <%= I18n.t("export_options.include_unpublished") %>&#160;
+            </label>
+            <%# END - MARC %>
+          </fieldset>
+        </div>
+      </li>
+
+
+      <li><%= link_to I18n.t("actions.container_labels"), {:controller => :exports, :action => :container_labels, :id => @resource.id}, :id => 'container-labels-link', :target => "_blank" %></li>
+
+      <% if user_can?('create_job') %>
+        <% if job_types['print_to_pdf_job']['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>
+
+          <li class="dropdown-submenu">
+            <%= link_to I18n.t("actions.print_to_pdf"), {:controller => :exports,  :action => :print_to_pdf, :id => @resource.id, :include_unpublished => true}, :id => 'print-to-pdf-link', :target => "_blank" %>
+            <div class="dropdown-menu">
+              <fieldset>
+                <label class="checkbox" for="include-unpublished-pdf">
+                  <input type="checkbox" id="include-unpublished-pdf" checked="true" onchange="$('#print-to-pdf-link').attr('href', '<%= url_for :controller => :exports,  :action => :print_to_pdf, :id => @resource.id %>?include_unpublished=' + $(this).prop('checked'))" />
+                  <%= I18n.t("export_options.include_unpublished") %>&#160;
+                </label>
+              </fieldset>
+            </div>
+          </li>
+
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= render_aspace_partial(:partial => '/shared/resource_toolbar',
+             :locals => {
+              :record_type => 'resource',
+              :record => @resource,
+             })
+  %>
+
+  <script>var ead_xform_id = <%= params[:id] %>;</script>
+  <%= javascript_include_tag "#{@base_url}/assets/ead_xform.js" %> 
+<% end %>


### PR DESCRIPTION
https://jira.huit.harvard.edu/browse/ARCSPC-427

Here I've overwritten the toolbar file instead of layout_head. This is due to ASpace core having behavior where it loads the toolbar twice. The bug was such that our code was actually working, and inserting our link, but the second load was overwriting it with a 'fresh' link-less dropdown menu.

I resolved the issue by inserting the script embed directly on the toolbar, so it will check with every load. This eliminates the need for any timers or things like that.