### PR TITLE
add new container template download option to export dropdown

### DIFF
--- a/frontend/views/resources/_toolbar.html.erb
+++ b/frontend/views/resources/_toolbar.html.erb
@@ -51,6 +51,7 @@
 
 
       <li><%= link_to I18n.t("actions.container_labels"), {:controller => :exports, :action => :container_labels, :id => @resource.id}, :id => 'container-labels-link', :target => "_blank" %></li>
+      <li><%= link_to I18n.t("actions.container_template"), {:controller => :exports, :action => :container_template, :id => @resource.id}, :id => 'container-template-link', :target => "_self" %></li>
 
       <% if user_can?('create_job') %>
         <% if job_types['print_to_pdf_job']['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>


### PR DESCRIPTION
aspace-ead-xform overwrites the core frontend/app/views/resource/_toolbar.html.erb; this change adds a line to the plugin overwrite so that the new option for downloading a container template appears when our plugin is used